### PR TITLE
Add in some simple multi-db support

### DIFF
--- a/gil/driver/index.js
+++ b/gil/driver/index.js
@@ -51,7 +51,13 @@ const createNeo4jPropertiesFromObject = obj => {
     return flattened;
 };
 
+const getSessionConfig = () => {
+    const database = process.env.NEO4J_DATABASE || false
+    return { ...(database ? { database } : {}) }
+}
+
 module.exports = {
     getDriver,
+    getSessionConfig,
     createNeo4jPropertiesFromObject,
 };

--- a/gil/sink/CUDBatch.js
+++ b/gil/sink/CUDBatch.js
@@ -47,7 +47,7 @@ class CUDBatch extends Strategy {
 
     /**
      * Creates an array of batches for a sequence of commands.
-     * @param {Array{CUDCommand}} commands 
+     * @param {Array{CUDCommand}} commands
      * @returns {Array[CUDBatch]}
      */
     static batchCommands(commands, maxBatchSize=MAX_BATCH_SIZE) {
@@ -67,7 +67,7 @@ class CUDBatch extends Strategy {
             if (activeBatch.canHold(command)) {
                 // console.log('adding to batch ', batches);
                 return activeBatch.add(command);
-            } 
+            }
 
             // console.log('created batch ', ++batches);
             results.push(activeBatch);
@@ -84,15 +84,16 @@ class CUDBatch extends Strategy {
 
     /**
      * Batch a set of commands for optimal execution, and run each batch.
-     * @param {Array{CUDCommand}} commands 
+     * @param {Array{CUDCommand}} commands
      * @returns {Promise} that resolves to an array of batch results.
      */
     static runAll(commands) {
         const batches = CUDBatch.batchCommands(commands);
 
-        const session = neo4j.getDriver().session();
+        const session = neo4j.getDriver()
+	    .session(neo4j.getSessionConfig());
 
-        return session.writeTransaction(tx => 
+        return session.writeTransaction(tx =>
             Promise.mapSeries(batches, batch => batch.run(tx)))
             .finally(session.close);
     }

--- a/gil/sink/DataSink.js
+++ b/gil/sink/DataSink.js
@@ -8,7 +8,7 @@ class DataSink {
 
     run() {
         const driver = neo4j.getDriver();
-        const session = driver.session();
+        const session = driver.session(neo4j.getSessionConfig());
 
         return Promise.mapSeries(this.strategies, strategy => strategy.run(session))
             .finally(session.close);


### PR DESCRIPTION
Adds support for a NEO4J_DATABASE environment variable that gets added to new sessions as a database configuration property (if present).

Some whitespace changes snuck in (thanks Emacs).